### PR TITLE
Return real Unit value in methods returning Unit

### DIFF
--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -347,7 +347,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes", queryParameters = queryParameters).map {
-          case r if r.getStatusCode == 204 => Unit
+          case r if r.getStatusCode == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
       }
@@ -360,7 +360,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters).map {
-          case r if r.getStatusCode == 204 => Unit
+          case r if r.getStatusCode == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
       }
@@ -542,7 +542,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       override def postNoop()(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         _executeRequest("POST", s"/users/noop").map {
-          case r if r.getStatusCode == 200 => Unit
+          case r if r.getStatusCode == 200 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
       }

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -386,7 +386,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes", queryParameters = queryParameters).map {
-          case r if r.status == 204 => Unit
+          case r if r.status == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
       }
@@ -399,7 +399,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters).map {
-          case r if r.status == 204 => Unit
+          case r if r.status == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
       }
@@ -581,7 +581,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       override def postNoop()(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         _executeRequest("POST", s"/users/noop").map {
-          case r if r.status == 200 => Unit
+          case r if r.status == 200 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
       }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -330,7 +330,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes", queryParameters = queryParameters).map {
-          case r if r.getStatusCode == 204 => Unit
+          case r if r.getStatusCode == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
       }
@@ -343,7 +343,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters).map {
-          case r if r.getStatusCode == 204 => Unit
+          case r if r.getStatusCode == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 204", requestUri = Some(r.getUri))
         }
       }
@@ -514,7 +514,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       override def postNoop()(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         _executeRequest("POST", s"/users/noop").map {
-          case r if r.getStatusCode == 200 => Unit
+          case r if r.getStatusCode == 200 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.getStatusCode, s"Unsupported response code[${r.getStatusCode}]. Expected: 200", requestUri = Some(r.getUri))
         }
       }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -369,7 +369,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes", queryParameters = queryParameters).map {
-          case r if r.status == 204 => Unit
+          case r if r.status == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
       }
@@ -382,7 +382,7 @@ package com.bryzek.apidoc.reference.api.v0 {
           requiredMessages.map("required_messages" -> _)
 
         _executeRequest("GET", s"/echoes/arrays-only", queryParameters = queryParameters).map {
-          case r if r.status == 204 => Unit
+          case r if r.status == 204 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 204")
         }
       }
@@ -553,7 +553,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       override def postNoop()(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Unit] = {
         _executeRequest("POST", s"/users/noop").map {
-          case r if r.status == 200 => Unit
+          case r if r.status == 200 => ()
           case r => throw new com.bryzek.apidoc.reference.api.v0.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
         }
       }

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
@@ -190,14 +190,14 @@ case class ScalaClientMethodGenerator(
               if (response.isSuccess) {
                 if (featureMigration.hasImplicit404s && response.isOption) {
                   if (response.isUnit) {
-                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => Some(Unit)")
+                    Some(s"case r if r.${config.responseStatusMethod} == $statusCode => Some(())")
                   } else {
                     val json = config.toJson("r", response.datatype.name)
                     Some(s"case r if r.${config.responseStatusMethod} == $statusCode => Some($json)")
                   }
 
                 } else if (response.isUnit) {
-                  Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ${response.datatype.name}")
+                  Some(s"case r if r.${config.responseStatusMethod} == $statusCode => ()")
 
                 } else {
                   val json = config.toJson("r", response.datatype.name)


### PR DESCRIPTION
The real singleton value for the Unit type is ().
Unit itself is a companion object with various useful utilities; only value discarding allows the generated code to compile correctly.

This should fix one issue that scala linters have with generated apidoc code.