### PR TITLE
Remove match from anonymous function generation.

### DIFF
--- a/example-union-types/generated/app/ApidocExampleUnionTypesClient.scala
+++ b/example-union-types/generated/app/ApidocExampleUnionTypesClient.scala
@@ -344,13 +344,11 @@ package com.bryzek.apidoc.example.union.types.v0 {
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
       ).withHeaders(defaultHeaders : _*)
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -297,19 +297,17 @@ package com.bryzek.apidoc.example.union.types.v0 {
 
       defaultHeaders.foreach { h => builder.addHeader(h._1, h._2) }
 
-      auth.fold(builder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            builder.setRealm(
-              new Realm.RealmBuilder()
-                .setPrincipal(username)
-                .setUsePreemptiveAuth(true)
-                .setScheme(Realm.AuthScheme.BASIC)
-                .build()
-            )
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(builder) {
+        case Authorization.Basic(username, password) => {
+          builder.setRealm(
+            new Realm.RealmBuilder()
+              .setPrincipal(username)
+              .setUsePreemptiveAuth(true)
+              .setScheme(Realm.AuthScheme.BASIC)
+              .build()
+          )
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -342,13 +342,11 @@ package com.bryzek.apidoc.example.union.types.v0 {
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
       ).withHeaders(defaultHeaders : _*)
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -156,19 +156,17 @@ package com.gilt.test.v0 {
 
       defaultHeaders.foreach { h => builder.addHeader(h._1, h._2) }
 
-      auth.fold(builder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            builder.setRealm(
-              new Realm.RealmBuilder()
-                .setPrincipal(username)
-                .setUsePreemptiveAuth(true)
-                .setScheme(Realm.AuthScheme.BASIC)
-                .build()
-            )
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(builder) {
+        case Authorization.Basic(username, password) => {
+          builder.setRealm(
+            new Realm.RealmBuilder()
+              .setPrincipal(username)
+              .setUsePreemptiveAuth(true)
+              .setScheme(Realm.AuthScheme.BASIC)
+              .build()
+          )
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -181,13 +181,11 @@ package com.gilt.test.v0 {
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
       ).withHeaders(defaultHeaders : _*)
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -561,19 +561,17 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       defaultHeaders.foreach { h => builder.addHeader(h._1, h._2) }
 
-      auth.fold(builder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            builder.setRealm(
-              new Realm.RealmBuilder()
-                .setPrincipal(username)
-                .setUsePreemptiveAuth(true)
-                .setScheme(Realm.AuthScheme.BASIC)
-                .build()
-            )
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(builder) {
+        case Authorization.Basic(username, password) => {
+          builder.setRealm(
+            new Realm.RealmBuilder()
+              .setPrincipal(username)
+              .setUsePreemptiveAuth(true)
+              .setScheme(Realm.AuthScheme.BASIC)
+              .build()
+          )
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -595,13 +595,11 @@ package com.bryzek.apidoc.reference.api.v0 {
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
       ).withHeaders(defaultHeaders : _*)
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -533,19 +533,17 @@ package com.bryzek.apidoc.reference.api.v0 {
 
       defaultHeaders.foreach { h => builder.addHeader(h._1, h._2) }
 
-      auth.fold(builder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            builder.setRealm(
-              new Realm.RealmBuilder()
-                .setPrincipal(username)
-                .setUsePreemptiveAuth(true)
-                .setScheme(Realm.AuthScheme.BASIC)
-                .build()
-            )
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(builder) {
+        case Authorization.Basic(username, password) => {
+          builder.setRealm(
+            new Realm.RealmBuilder()
+              .setPrincipal(username)
+              .setUsePreemptiveAuth(true)
+              .setScheme(Realm.AuthScheme.BASIC)
+              .build()
+          )
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -567,13 +567,11 @@ package com.bryzek.apidoc.reference.api.v0 {
         "X-Apidoc-Version" -> Constants.Version,
         "X-Apidoc-Version-Major" -> Constants.VersionMajor.toString
       ).withHeaders(defaultHeaders : _*)
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), play.api.libs.ws.WSAuthScheme.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
@@ -130,13 +130,11 @@ ${methodGenerator.objects().indent(4)}
       import play.api.Play.current
 
       val holder = play.api.libs.ws.WS.url(apiUrl + path)$headerString
-      auth.fold(holder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            holder.withAuth(username, password.getOrElse(""), ${version.authSchemeClass}.BASIC)
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(holder) {
+        case Authorization.Basic(username, password) => {
+          holder.withAuth(username, password.getOrElse(""), ${version.authSchemeClass}.BASIC)
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 

--- a/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/ning/NingClientGenerator.scala
@@ -98,19 +98,17 @@ ${headerString.indent(8)}
 
       defaultHeaders.foreach { h => builder.addHeader(h._1, h._2) }
 
-      auth.fold(builder) { a =>
-        a match {
-          case Authorization.Basic(username, password) => {
-            builder.setRealm(
-              new Realm.RealmBuilder()
-                .setPrincipal(username)
-                .setUsePreemptiveAuth(true)
-                .setScheme(Realm.AuthScheme.BASIC)
-                .build()
-            )
-          }
-          case _ => sys.error("Invalid authorization scheme[" + a.getClass + "]")
+      auth.fold(builder) {
+        case Authorization.Basic(username, password) => {
+          builder.setRealm(
+            new Realm.RealmBuilder()
+              .setPrincipal(username)
+              .setUsePreemptiveAuth(true)
+              .setScheme(Realm.AuthScheme.BASIC)
+              .build()
+          )
         }
+        case a => sys.error("Invalid authorization scheme[" + a.getClass + "]")
       }
     }
 


### PR DESCRIPTION
You can replace an anonymous function which consists only of a match, with a partial function instead. The code is a bit more succinct, and less prone to having linters complain.
In this case, we can also be sure that all possible values are matched, because of the catch-all option.