### PR TITLE
Fix scala json union type reader is not deserializing unknown type

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -196,6 +196,8 @@ package com.bryzek.apidoc.example.union.types.v0.models {
         (__ \ "foo").read(jsonReadsApidocExampleUnionTypesFoo).asInstanceOf[play.api.libs.json.Reads[Foobar]]
         orElse
         (__ \ "bar").read(jsonReadsApidocExampleUnionTypesBar).asInstanceOf[play.api.libs.json.Reads[Foobar]]
+        orElse
+        play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(com.bryzek.apidoc.example.union.types.v0.models.FoobarUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[Foobar]]]
       )
     }
 
@@ -214,6 +216,8 @@ package com.bryzek.apidoc.example.union.types.v0.models {
         (__ \ "guest_user").read(jsonReadsApidocExampleUnionTypesGuestUser).asInstanceOf[play.api.libs.json.Reads[User]]
         orElse
         (__ \ "uuid").read(jsonReadsApidocExampleUnionTypesUserUuid).asInstanceOf[play.api.libs.json.Reads[User]]
+        orElse
+        play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(com.bryzek.apidoc.example.union.types.v0.models.UserUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[User]]]
       )
     }
 

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -196,6 +196,8 @@ package com.bryzek.apidoc.example.union.types.v0.models {
         (__ \ "foo").read(jsonReadsApidocExampleUnionTypesFoo).asInstanceOf[play.api.libs.json.Reads[Foobar]]
         orElse
         (__ \ "bar").read(jsonReadsApidocExampleUnionTypesBar).asInstanceOf[play.api.libs.json.Reads[Foobar]]
+        orElse
+        play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(com.bryzek.apidoc.example.union.types.v0.models.FoobarUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[Foobar]]]
       )
     }
 
@@ -214,6 +216,8 @@ package com.bryzek.apidoc.example.union.types.v0.models {
         (__ \ "guest_user").read(jsonReadsApidocExampleUnionTypesGuestUser).asInstanceOf[play.api.libs.json.Reads[User]]
         orElse
         (__ \ "uuid").read(jsonReadsApidocExampleUnionTypesUserUuid).asInstanceOf[play.api.libs.json.Reads[User]]
+        orElse
+        play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(com.bryzek.apidoc.example.union.types.v0.models.UserUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[User]]]
       )
     }
 

--- a/lib/src/test/resources/scala-nested-union-models-json-union-type-readers-inner-type.txt
+++ b/lib/src/test/resources/scala-nested-union-models-json-union-type-readers-inner-type.txt
@@ -1,5 +1,7 @@
 implicit def jsonReadsApiDocTestInnerType: play.api.libs.json.Reads[InnerType] = {
   (
     (__ \ "string_model").read(jsonReadsApiDocTestStringModel).asInstanceOf[play.api.libs.json.Reads[InnerType]]
+    orElse
+    play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.InnerTypeUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[InnerType]]]
   )
 }

--- a/lib/src/test/resources/scala-nested-union-models-json-union-type-readers-outer-type.txt
+++ b/lib/src/test/resources/scala-nested-union-models-json-union-type-readers-outer-type.txt
@@ -1,5 +1,7 @@
 implicit def jsonReadsApiDocTestOuterType: play.api.libs.json.Reads[OuterType] = {
   (
     (__ \ "inner_type").read(jsonReadsApiDocTestOuterType).asInstanceOf[play.api.libs.json.Reads[OuterType]]
+    orElse
+    play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.OuterTypeUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[OuterType]]]
   )
 }

--- a/lib/src/test/resources/scala-union-enums-json.txt
+++ b/lib/src/test/resources/scala-union-enums-json.txt
@@ -3,6 +3,8 @@ implicit def jsonReadsApiDocTestUserType: play.api.libs.json.Reads[UserType] = {
     (__ \ "member_type").read(jsonReadsApiDocTestMemberType).asInstanceOf[play.api.libs.json.Reads[UserType]]
     orElse
     (__ \ "role_type").read(jsonReadsApiDocTestRoleType).asInstanceOf[play.api.libs.json.Reads[UserType]]
+    orElse
+    play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.UserTypeUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[UserType]]]
   )
 }
 

--- a/lib/src/test/resources/scala-union-models-json-union-type-readers.txt
+++ b/lib/src/test/resources/scala-union-models-json-union-type-readers.txt
@@ -3,5 +3,7 @@ implicit def jsonReadsApiDocTestUser: play.api.libs.json.Reads[User] = {
     (__ \ "registered_user").read(jsonReadsApiDocTestRegisteredUser).asInstanceOf[play.api.libs.json.Reads[User]]
     orElse
     (__ \ "guest_user").read(jsonReadsApiDocTestGuestUser).asInstanceOf[play.api.libs.json.Reads[User]]
+    orElse
+    play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.UserUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[User]]]
   )
 }

--- a/lib/src/test/resources/scala-union-models-json.txt
+++ b/lib/src/test/resources/scala-union-models-json.txt
@@ -39,6 +39,8 @@ implicit def jsonReadsApiDocTestUser: play.api.libs.json.Reads[User] = {
     (__ \ "registered_user").read(jsonReadsApiDocTestRegisteredUser).asInstanceOf[play.api.libs.json.Reads[User]]
     orElse
     (__ \ "guest_user").read(jsonReadsApiDocTestGuestUser).asInstanceOf[play.api.libs.json.Reads[User]]
+    orElse
+    play.api.libs.json.Reads(jsValue => play.api.libs.json.JsSuccess(test.apidoc.apidoctest.v0.models.UserUndefinedType(jsValue.toString))).asInstanceOf[play.api.libs.json.Reads[User]]]
   )
 }
 


### PR DESCRIPTION
scala> Json.parse("""{"foo":"bar"}""").validate[com.example.SomeUnion].get
res1: com.example.SomeUnion = SomeUnionUndefinedType({"foo":"bar"})
