### PR TITLE
Refactor deprecated method Column.nonNull1 --> Column.nonNull 

### DIFF
--- a/lib/src/test/resources/generator/anorm/enum-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/enum-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/list-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/list-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/location-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/location-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/name-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/name-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/reference-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/reference-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/union-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/union-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/lib/src/test/resources/generator/anorm/user-conversions.txt
+++ b/lib/src/test/resources/generator/anorm/user-conversions.txt
@@ -15,7 +15,7 @@ package test.apidoc.apidoctest.v0.anorm.conversions {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {

--- a/scala-generator/src/main/scala/models/generator/anorm/Conversions.scala
+++ b/scala-generator/src/main/scala/models/generator/anorm/Conversions.scala
@@ -32,7 +32,7 @@ package %s {
 
     def parser[T](
       f: play.api.libs.json.JsValue => T
-    ) = anorm.Column.nonNull1 { (value, meta) =>
+    ) = anorm.Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {
         case json: org.postgresql.util.PGobject => {


### PR DESCRIPTION
In ```com.typesafe.play.anorm:2.5.1``` (current dependency in apidoc - https://github.com/mbryzek/apidoc/blob/master/build.sbt#L79), ```nonNull1``` was deprecated.

Replacing with ```nonNull``` for Scala generated code.