### PR TITLE
Add a Play 2.5 Client

### DIFF
--- a/generator/app/controllers/Generators.scala
+++ b/generator/app/controllers/Generators.scala
@@ -108,6 +108,16 @@ object Generators {
         status = lib.generator.Status.Beta,
         codeGenerator = Some(scala.models.Play24ClientGenerator)
       ),
+    CodeGenTarget(
+      metaData = Generator(
+        key = "play_2_5_client",
+        name = "Play 2.5 client",
+        description = Some("Play Framework 2.5 client based on <a href='http://www.playframework.com/documentation/2.5.x/ScalaWS'>WS API</a>. Primary change from 2.3.x is WSRequestHolder has been deprecated (replaced by WSRequest)."),
+        language = Some("Scala")
+      ),
+      status = lib.generator.Status.Beta,
+      codeGenerator = Some(scala.models.Play25ClientGenerator)
+    ),
       CodeGenTarget(
         metaData = Generator(
           key = "play_2_x_json",
@@ -201,13 +211,13 @@ object Generators {
       ),
        CodeGenTarget(
         metaData = Generator(
-          key = "play_2_4_mock_client",
-          name = "Play 2.4 Mock Client",
+          key = "play_2_5_mock_client",
+          name = "Play 2.5 Mock Client",
           description = Some("Provides a mock client with non functional, but compiling stubs, that can serve as a baseline for testing"),
           language = Some("Java, Scala")
         ),
         status = lib.generator.Status.Alpha,
-        codeGenerator = Some(scala.generator.mock.MockClientGenerator.Play24)
-      )    
+        codeGenerator = Some(scala.generator.mock.MockClientGenerator.Play25)
+      )
   ).sortBy(_.metaData.key)
 }

--- a/scala-generator/src/main/scala/models/generator/ScalaClientCommon.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientCommon.scala
@@ -21,7 +21,7 @@ object ScalaClientCommon {
 
     s"""
 class Client(
-  val baseUrl: String$defaultUrl,
+  ${if (config.expectsInjectedWsClient) "ws: play.api.libs.ws.WSClient,\n  " else ""}val baseUrl: String$defaultUrl,
   auth: scala.Option[${config.namespace}.Authorization] = None,
   defaultHeaders: Seq[(String, String)] = Nil${config.extraClientCtorArgs.getOrElse("")}
 ) extends interfaces.Client

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodConfig.scala
@@ -37,6 +37,11 @@ trait ScalaClientMethodConfig {
     */
   def responseClass: String
 
+  /** Whether or not play.api.libs.ws.WS exists as a static object, or if
+    * play.api.libs.ws.WSClient is expected to be passed in.
+   */
+  def expectsInjectedWsClient: Boolean
+
   /**
     * Extra arguments that we need to provide to the Client, like e.g.
     * our own async http client
@@ -77,6 +82,7 @@ object ScalaClientMethodConfigs {
     override def pathEncode(value: String) = s"""play.utils.UriEncoding.encodePathSegment($value, "UTF-8")"""
     override val responseStatusMethod = "status"
     override val responseBodyMethod = "body"
+    override val expectsInjectedWsClient = false
     override val extraClientCtorArgs = None
     override val extraClientObjectMethods = None
     override val implicitArgs = Some("(implicit ec: scala.concurrent.ExecutionContext)")
@@ -85,18 +91,28 @@ object ScalaClientMethodConfigs {
   case class Play22(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.Response"
     override val requestUriMethod = Some("ahcResponse.getUri")
+    override val expectsInjectedWsClient = false
     override val canSerializeUuid = false
   }
 
   case class Play23(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
     override val requestUriMethod = None
+    override val expectsInjectedWsClient = false
     override val canSerializeUuid = true
   }
 
   case class Play24(namespace: String, baseUrl: Option[String]) extends Play {
     override val responseClass = "play.api.libs.ws.WSResponse"
     override val requestUriMethod = None
+    override val expectsInjectedWsClient = false
+    override val canSerializeUuid = true
+  }
+
+  case class Play25(namespace: String, baseUrl: Option[String]) extends Play {
+    override val responseClass = "play.api.libs.ws.WSResponse"
+    override val requestUriMethod = None
+    override val expectsInjectedWsClient = true
     override val canSerializeUuid = true
   }
 
@@ -124,11 +140,13 @@ private lazy val defaultAsyncHttpClient = {
   case class Ning18(namespace: String, baseUrl: Option[String]) extends Ning {
     override def addQueryParamMethod: String = "addQueryParameter"
     override val requestUriMethod = Some("getUri")
+    override val expectsInjectedWsClient = false
   }
 
   case class Ning19(namespace: String, baseUrl: Option[String]) extends Ning {
     override def addQueryParamMethod: String = "addQueryParam"
     override val requestUriMethod = Some("getUri.toJavaNetURI")
+    override val expectsInjectedWsClient = false
   }
 
 }

--- a/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
@@ -1,21 +1,19 @@
 package scala.generator.mock
 
-import com.bryzek.apidoc.spec.v0.models.Service
 import com.bryzek.apidoc.generator.v0.models.{File, InvocationForm}
 import generator.ServiceFileNames
 import lib.generator.CodeGenerator
-import lib.{Datatype, Text}
 import lib.Text._
 import scala.models.ApidocComments
 import scala.generator._
 
 object MockClientGenerator {
 
-  object Play24 extends CodeGenerator {
+  object Play25 extends CodeGenerator {
 
     override def invoke(form: InvocationForm) = {
       val ssd = new ScalaService(form.service)
-      MockClientGenerator(form, ScalaClientMethodConfigs.Play24(ssd.namespaces.base, None)).invoke()
+      MockClientGenerator(form, ScalaClientMethodConfigs.Play25(ssd.namespaces.base, None)).invoke()
     }
 
   }


### PR DESCRIPTION
This closes #93.

The Play 2.4 Client fails in Play 2.5 with this error:

java.lang.InstantiationException: play.api.libs.ws.WSAPI

Passing in the WSClient resolves this, though it changes the method
signature when instantiating the Client class.