### PR TITLE
Use Play's `DefaultJodaDateReads` to catch JS validation errors

### DIFF
--- a/scala-generator/src/main/scala/models/Play2Models.scala
+++ b/scala-generator/src/main/scala/models/Play2Models.scala
@@ -53,21 +53,17 @@ trait Play2Models extends CodeGenerator {
 package ${ssd.namespaces.models} {
 
   package object json {
+    import play.api.libs.functional.syntax._
     import play.api.libs.json.__
     import play.api.libs.json.JsString
     import play.api.libs.json.Writes
-    import play.api.libs.functional.syntax._
+    import play.api.libs.json.Reads.DefaultJodaDateReads
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
     private[${ssd.namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
     private[${ssd.namespaces.last}] implicit val jsonWritesUUID = new Writes[java.util.UUID] {
       def writes(x: java.util.UUID) = JsString(x.toString)
-    }
-
-    private[${ssd.namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-      dateTimeParser.parseDateTime(str)
     }
 
     private[${ssd.namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {


### PR DESCRIPTION
This change is in response to noticing that an invalid DateTime received via POST causes an internal server error, when it is in fact a JSON validation error.

Play provides `DefaultJodaDateReads` for (at least) versions 2.2.x and higher [(source)](https://github.com/playframework/playframework/blob/2.2.x/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala#L292-L295).