### PR TITLE
Ruby client: Improve error msg for union type

### DIFF
--- a/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
+++ b/ruby-generator/src/main/scala/models/RubyClientGenerator.scala
@@ -691,7 +691,10 @@ ${headers.rubyModuleConstants.indent(2)}
         Seq(
           s"def $className.from_json(hash)",
           s"  HttpClient::Preconditions.assert_class('hash', hash, Hash)",
-          s"  discriminator = HttpClient::Helper.symbolize_keys(hash)[:$disc]",
+          s"  discriminator = HttpClient::Helper.symbolize_keys(hash)[:$disc].to_s.strip",
+          s"  if discriminator.empty?",
+          s"""    raise "Union type[${union.name}] requires a field named '$disc'"""",
+          s"  end",
           s"  case discriminator",
           union.types.map { ut =>
             Datatype.Primitive(ut.`type`) match {


### PR DESCRIPTION
- Ex: Union type[foo] requires a field named 'discriminator'