### PR TITLE
Start of adding @deprecated to generated scala resources

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -6,7 +6,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
 
   sealed trait Foobar
 
-  sealed trait User
+  @deprecated("to be removed") sealed trait User
 
   case class GuestUser(
     guid: _root_.java.util.UUID,
@@ -47,9 +47,9 @@ package com.bryzek.apidoc.example.union.types.v0.models {
 
   sealed trait Bar extends Foobar
 
-  object Bar {
+  @deprecated("to be removed") object Bar {
 
-    case object B extends Bar { override def toString = "b" }
+    @deprecated case object B extends Bar { override def toString = "b" }
 
     /**
      * UNDEFINED captures values that are sent either in error or

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -6,7 +6,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
 
   sealed trait Foobar
 
-  sealed trait User
+  @deprecated("to be removed") sealed trait User
 
   case class GuestUser(
     guid: _root_.java.util.UUID,
@@ -47,9 +47,9 @@ package com.bryzek.apidoc.example.union.types.v0.models {
 
   sealed trait Bar extends Foobar
 
-  object Bar {
+  @deprecated("to be removed") object Bar {
 
-    case object B extends Bar { override def toString = "b" }
+    @deprecated case object B extends Bar { override def toString = "b" }
 
     /**
      * UNDEFINED captures values that are sent either in error or

--- a/lib/src/test/resources/examples/apidoc-example-union-types.json
+++ b/lib/src/test/resources/examples/apidoc-example-union-types.json
@@ -21,10 +21,14 @@
       "values": [
         {
           "name": "b",
-          "attributes": []
+          "attributes": [],
+          "deprecation": {}
         }
       ],
-      "attributes": []
+      "attributes": [],
+      "deprecation": {
+        "description": "to be removed"
+      }
     },
     {
       "name": "foo",
@@ -68,10 +72,14 @@
         },
         {
           "type": "uuid",
-          "attributes": []
+          "attributes": [],
+          "deprecation": {}
         }
       ],
-      "attributes": []
+      "attributes": [],
+      "deprecation": {
+        "description": "to be removed"
+      }
     }
   ],
   "models": [

--- a/lib/src/test/resources/examples/collection-json-defaults.json
+++ b/lib/src/test/resources/examples/collection-json-defaults.json
@@ -24,7 +24,9 @@
       "name": "user",
       "plural": "users",
       "description": null,
-      "deprecation": null,
+      "deprecation": {
+        "description": "to be merged with members"
+      },
       "attributes": [],
       "fields": [
         {
@@ -37,7 +39,7 @@
           "minimum": null,
           "maximum": null,
           "example": null,
-          "attributes": []          
+          "attributes": []
         },
         {
           "name": "role",
@@ -67,7 +69,7 @@
           "name": "permissions",
           "type": "[string]",
           "description": null,
-          "deprecation": null,
+          "deprecation": {},
           "default": null,
           "required": true,
           "minimum": null,
@@ -128,7 +130,9 @@
       "type": "user",
       "plural": "users",
       "description": null,
-      "deprecation": null,
+      "deprecation": {
+        "description": "users will be transfered to the members endpoint"
+      },
       "attributes": [],
       "operations": [
         {
@@ -157,7 +161,9 @@
           "method": "GET",
           "path": "/users/:email",
           "description": null,
-          "deprecation": null,
+          "deprecation": {
+            "description": "to be removed"
+          },
           "body": null,
           "attributes": [],
           "parameters": [
@@ -166,7 +172,8 @@
               "type": "string",
               "location": "Path",
               "description": null,
-              "deprecation": null,
+              "deprecation": {
+              },
               "required": true,
               "default": null,
               "minimum": null,
@@ -202,7 +209,9 @@
               "code": { "integer": { "value": 200 } },
               "type": "user",
               "description": null,
-              "deprecation": null
+              "deprecation": {
+                "description": "This will return a 201 in the future"
+              }
             }
           ]
         }

--- a/lib/src/test/resources/examples/quality.json
+++ b/lib/src/test/resources/examples/quality.json
@@ -459,6 +459,9 @@
           "type": "team",
           "description": "Team responsible for resolution of this incident",
           "required": false,
+          "deprecation": {
+            "description": "to be removed in a future version"
+          },
           "attributes": []
         },
         {
@@ -472,6 +475,7 @@
           "type": "[string]",
           "description": "Optional list of tags to apply to this incident",
           "required": false,
+          "deprecation": {},
           "attributes": []
         },
         {
@@ -1084,6 +1088,9 @@
               "location": "Query",
               "description": "Find agenda items for this team",
               "required": false,
+              "deprecation": {
+                "description": "to be removed in a future version"
+              },
               "attributes": []
             },
             {

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -4,11 +4,11 @@
  */
 package com.gilt.test.v0.models {
 
-  case class User(
+  @deprecated("to be merged with members") case class User(
     email: String,
     role: String = "admin",
     groups: Seq[String],
-    permissions: Seq[String]
+    @deprecated permissions: Seq[String]
   )
 
   case class UserPatch(
@@ -132,7 +132,7 @@ package com.gilt.test.v0 {
 
     def users: Users = Users
 
-    object Users extends Users {
+    @deprecated("users will be transfered to the members endpoint") object Users extends Users {
       override def post(
         user: com.gilt.test.v0.models.User,
         requestHeaders: Seq[(String, String)] = Nil
@@ -145,8 +145,8 @@ package com.gilt.test.v0 {
         }
       }
 
-      override def getByEmail(
-        email: String,
+      @deprecated("to be removed") override def getByEmail(
+        @deprecated email: String,
         requestHeaders: Seq[(String, String)] = Nil
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         _executeRequest("GET", s"/users/${_root_.com.gilt.test.v0.PathSegment.encode(email, "UTF-8")}", requestHeaders = requestHeaders).map {
@@ -291,8 +291,8 @@ package com.gilt.test.v0 {
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
-    def getByEmail(
-      email: String,
+    @deprecated("to be removed") def getByEmail(
+      @deprecated email: String,
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -4,11 +4,11 @@
  */
 package com.gilt.test.v0.models {
 
-  case class User(
+  @deprecated("to be merged with members") case class User(
     email: String,
     role: String = "admin",
     groups: Seq[String],
-    permissions: Seq[String]
+    @deprecated permissions: Seq[String]
   )
 
   case class UserPatch(
@@ -159,7 +159,7 @@ package com.gilt.test.v0 {
 
     def users: Users = Users
 
-    object Users extends Users {
+    @deprecated("users will be transfered to the members endpoint") object Users extends Users {
       override def post(
         user: com.gilt.test.v0.models.User,
         requestHeaders: Seq[(String, String)] = Nil
@@ -172,8 +172,8 @@ package com.gilt.test.v0 {
         }
       }
 
-      override def getByEmail(
-        email: String,
+      @deprecated("to be removed") override def getByEmail(
+        @deprecated email: String,
         requestHeaders: Seq[(String, String)] = Nil
       )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User] = {
         _executeRequest("GET", s"/users/${play.utils.UriEncoding.encodePathSegment(email, "UTF-8")}", requestHeaders = requestHeaders).map {
@@ -309,8 +309,8 @@ package com.gilt.test.v0 {
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 
-    def getByEmail(
-      email: String,
+    @deprecated("to be removed") def getByEmail(
+      @deprecated email: String,
       requestHeaders: Seq[(String, String)] = Nil
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[com.gilt.test.v0.models.User]
 

--- a/lib/src/test/resources/generators/collection-json-defaults-user-case-class.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-user-case-class.txt
@@ -1,6 +1,6 @@
-case class User(
+@deprecated("to be merged with members") case class User(
   email: String,
   role: String = "admin",
   groups: Seq[String],
-  permissions: Seq[String]
+  @deprecated permissions: Seq[String]
 )

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -82,7 +82,7 @@ package com.gilt.quality.v0.models {
   )
 
   case class Healthcheck(
-    status: String
+    @deprecated("please use audience.label instead") status: String
   )
 
   /**
@@ -101,9 +101,9 @@ package com.gilt.quality.v0.models {
     organization: com.gilt.quality.v0.models.Organization,
     summary: String,
     description: _root_.scala.Option[String] = None,
-    team: _root_.scala.Option[com.gilt.quality.v0.models.Team] = None,
+    @deprecated("to be removed in a future version") team: _root_.scala.Option[com.gilt.quality.v0.models.Team] = None,
     severity: com.gilt.quality.v0.models.Severity,
-    tags: _root_.scala.Option[Seq[String]] = None,
+    @deprecated tags: _root_.scala.Option[Seq[String]] = None,
     plan: _root_.scala.Option[com.gilt.quality.v0.models.Plan] = None,
     createdAt: _root_.org.joda.time.DateTime
   )

--- a/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
@@ -85,7 +85,7 @@ trait ScalaCaseClasses extends CodeGenerator {
 
   def generateUnionTrait(union: ScalaUnion): String = {
     // TODO: handle primitive types
-    s"sealed trait ${union.name}"
+    s"${ScalaUtil.deprecationString(union.deprecation)}sealed trait ${union.name}"
   }
 
   def generateCaseClassWithDoc(model: ScalaModel, unions: Seq[ScalaUnion]): String = {
@@ -93,7 +93,7 @@ trait ScalaCaseClasses extends CodeGenerator {
   }
 
   def generateCaseClass(model: ScalaModel, unions: Seq[ScalaUnion]): String = {
-    s"case class ${model.name}(${model.argList.getOrElse("")})" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse("")
+    s"${ScalaUtil.deprecationString(model.deprecation)}case class ${model.name}(${model.argList.getOrElse("")})" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse("")
   }
 
   def generateEnum(ssd: ScalaService, enum: ScalaEnum): String = {

--- a/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientMethodGenerator.scala
@@ -64,7 +64,7 @@ case class ScalaClientMethodGenerator(
 
   def objects(): String = {
     sortedResources.map { resource =>
-      s"object ${resource.plural} extends ${resource.plural} {\n" +
+      s"${ScalaUtil.deprecationString(resource.deprecation)}object ${resource.plural} extends ${resource.plural} {\n" +
       methods(resource).map(_.code).mkString("\n\n").indent(2) +
       "\n}"
     }.mkString("\n\n")
@@ -286,11 +286,11 @@ case class ScalaClientMethod(
   private[this] val commentString = comments.map(string => ScalaUtil.textToComment(string) + "\n").getOrElse("")
 
   val interface: String = {
-    s"""${commentString}def $name(${argList.getOrElse("")})${implicitArgs.getOrElse("")}: $returnType"""
+    s"""${commentString}${ScalaUtil.deprecationString(operation.deprecation)}def $name(${argList.getOrElse("")})${implicitArgs.getOrElse("")}: $returnType"""
   }
 
   val code: String = {
-    s"""override def $name(${argList.getOrElse("")})${implicitArgs.getOrElse("")}: $returnType = {
+    s"""${ScalaUtil.deprecationString(operation.deprecation)}override def $name(${argList.getOrElse("")})${implicitArgs.getOrElse("")}: $returnType = {
 ${methodCall.indent}.map {
 ${response.indent(4)}
   }

--- a/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaDatatype.scala
@@ -9,6 +9,8 @@ import lib.Text.initLowerCase
 import play.api.libs.json._
 import play.api.Logger
 
+import com.bryzek.apidoc.spec.v0.models.Deprecation
+
 sealed trait ScalaDatatype {
   def asString(originalVarName: String): String = {
     throw new UnsupportedOperationException(s"unsupported conversion of type ${name} for var $originalVarName")
@@ -16,12 +18,16 @@ sealed trait ScalaDatatype {
 
   def name: String
 
+  def deprecationString(deprecation: Option[Deprecation]): String =
+    ScalaUtil.deprecationString(deprecation)
+
   def definition(
     originalVarName: String,
-    default: Option[String]
+    default: Option[String],
+    deprecation: Option[Deprecation]
   ): String = {
     val varName = ScalaUtil.quoteNameIfKeyword(originalVarName)
-    default.fold(s"$varName: $name") { default =>
+    default.fold(s"${deprecationString(deprecation)}$varName: $name") { default =>
       s"$varName: $name = $default"
     }
   }
@@ -269,11 +275,12 @@ object ScalaDatatype {
 
     override def definition(
       originalVarName: String,
-      default: scala.Option[String]
+      default: scala.Option[String],
+      deprecation: scala.Option[Deprecation]
     ): String = {
       require(default.isEmpty, s"no defaults allowed on options: ${default}")
       val varName = ScalaUtil.quoteNameIfKeyword(originalVarName)
-      s"$varName: $name = None"
+      s"${deprecationString(deprecation)}$varName: $name = None"
     }
 
     // override, since options contain at most one element

--- a/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
@@ -19,7 +19,7 @@ case class ScalaEnums(
     Seq(
       enum.description.map { desc => ScalaUtil.textToComment(desc) + "\n" }.getOrElse("") +
       s"sealed trait ${enum.name}" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse(""),
-      s"object ${enum.name} {",
+      s"${ScalaUtil.deprecationString(enum.deprecation)}object ${enum.name} {",
       buildValues().indent(2),
       s"}"
     ).mkString("\n\n")
@@ -68,10 +68,10 @@ case class ScalaEnums(
   }
 
   private def buildValues(): String = {
-    enum.values.map { value => 
+    enum.values.map { value =>
       Seq(
         value.description.map { desc => ScalaUtil.textToComment(desc) },
-        Some(s"""case object ${value.name} extends ${enum.name} { override def toString = "${value.originalName}" }""")
+        Some(s"""${ScalaUtil.deprecationString(value.deprecation)}case object ${value.name} extends ${enum.name} { override def toString = "${value.originalName}" }""")
       ).flatten.mkString("\n")
     }.mkString("\n") + "\n" +
     s"""

--- a/scala-generator/src/main/scala/models/generator/ScalaService.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaService.scala
@@ -15,7 +15,7 @@ case class ScalaService(
   val datatypeResolver = GeneratorUtil.datatypeResolver(service)
 
   val name = ScalaUtil.toClassName(service.name)
- 
+
   def unionClassName(name: String) = namespaces.unions + "." + ScalaUtil.toClassName(name)
   def modelClassName(name: String) = namespaces.models + "." + ScalaUtil.toClassName(name)
   def enumClassName(name: String) = namespaces.enums + "." + ScalaUtil.toClassName(name)
@@ -67,7 +67,7 @@ class ScalaUnion(val ssd: ScalaService, val union: Union) {
   val qualifiedName = ssd.unionClassName(name)
 
   val discriminator: Option[String] = union.discriminator
-  
+
   val description: Option[String] = union.description
 
   // Include an undefined instance to nudge the developer to think
@@ -76,6 +76,8 @@ class ScalaUnion(val ssd: ScalaService, val union: Union) {
   val undefinedType = ScalaPrimitive.Model(ssd.namespaces, name + "UndefinedType")
 
   val types: Seq[ScalaUnionType] = union.types.map { ScalaUnionType(ssd, union, _) }
+
+  val deprecation: Option[Deprecation] = union.deprecation
 
 }
 
@@ -150,6 +152,8 @@ class ScalaModel(val ssd: ScalaService, val model: Model) {
 
   val argList: Option[String] = ScalaUtil.fieldsToArgList(fields.map(_.definition()))
 
+  val deprecation: Option[Deprecation] = model.deprecation
+
 }
 
 class ScalaBody(ssd: ScalaService, val body: Body) {
@@ -179,6 +183,8 @@ class ScalaEnum(val ssd: ScalaService, val enum: Enum) {
 
   val values: Seq[ScalaEnumValue] = enum.values.map { new ScalaEnumValue(_) }
 
+  val deprecation: Option[Deprecation] = enum.deprecation
+
 }
 
 class ScalaEnumValue(value: EnumValue) {
@@ -188,6 +194,8 @@ class ScalaEnumValue(value: EnumValue) {
   val name: String = ScalaUtil.toClassName(value.name)
 
   val description: Option[String] = value.description
+
+  val deprecation: Option[Deprecation] = value.deprecation
 
 }
 
@@ -201,6 +209,8 @@ class ScalaResource(ssd: ScalaService, val resource: Resource) {
 
   val operations = resource.operations.map { new ScalaOperation(ssd, _, this)}
 
+  val deprecation: Option[Deprecation] = resource.deprecation
+
 }
 
 class ScalaOperation(val ssd: ScalaService, operation: Operation, resource: ScalaResource) {
@@ -208,6 +218,8 @@ class ScalaOperation(val ssd: ScalaService, operation: Operation, resource: Scal
   val method: Method = operation.method
 
   val path: String = operation.path
+
+  val deprecation: Option[Deprecation] = operation.deprecation
 
   val description: Option[String] = operation.description
 
@@ -312,7 +324,7 @@ class ScalaField(ssd: ScalaService, modelName: String, field: Field) {
   def default = field.default.map(ScalaUtil.scalaDefault(_, datatype))
 
   def definition(varName: String = name): String = {
-    datatype.definition(varName, default)
+    datatype.definition(varName, default, field.deprecation)
   }
 }
 
@@ -335,7 +347,7 @@ class ScalaParameter(ssd: ScalaService, val param: Parameter) {
   def required = param.required
 
   def definition(varName: String = name): String = {
-    datatype.definition(varName, default)
+    datatype.definition(varName, default, param.deprecation)
   }
 
   def location = param.location

--- a/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUtil.scala
@@ -8,6 +8,8 @@ import lib.generator.GeneratorUtil
 import play.api.libs.json._
 import org.joda.time.DateTime
 
+import com.bryzek.apidoc.spec.v0.models.Deprecation
+
 object ScalaUtil {
 
   private[this] val ReservedWords = Seq(
@@ -90,5 +92,14 @@ object ScalaUtil {
       throw new RuntimeException(s"parsing default `$value` for datatype $datatype", e)
     }
   }
+
+  def deprecationString(deprecation: Option[Deprecation]): String = {
+    val deprecationString: String = deprecation.map { dep =>
+      val description = dep.description.map { desc => s"""("$desc")""" }.getOrElse("")
+      s"@deprecated$description "
+    }.getOrElse("")
+    deprecationString
+  }
+
 }
 


### PR DESCRIPTION
Addresses mbryzek/apidoc#315

Open questions:

Versioning currently unsupported, as generators do not store/track
apidoc versions. Should we add another attribute on deprecation to
support?
How to represent deprecation for a response body?
How to represent deprecation of a class in a union, but not the class
itself