### PR TITLE
Fix problem with String/Enumerable in Ruby client

### DIFF
--- a/lib/src/test/resources/example-response-with-unit-type.txt
+++ b/lib/src/test/resources/example-response-with-unit-type.txt
@@ -261,7 +261,7 @@ module Com
             private
             def to_query(params={})
               parts = (params || {}).map { |k,v|
-                if v.respond_to?(:each)
+                if v.is_a?(Enumerable)
                   v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                 else
                   "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -537,7 +537,7 @@ module Com
                   private
                   def to_query(params={})
                     parts = (params || {}).map { |k,v|
-                      if v.respond_to?(:each)
+                      if v.is_a?(Enumerable)
                         v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                       else
                         "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/lib/src/test/resources/generators/collection-json-defaults-ruby-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ruby-client.txt
@@ -305,7 +305,7 @@ module Com
             private
             def to_query(params={})
               parts = (params || {}).map { |k,v|
-                if v.respond_to?(:each)
+                if v.is_a?(Enumerable)
                   v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                 else
                   "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/lib/src/test/resources/generators/generators/reference-spec-ruby-client.txt
+++ b/lib/src/test/resources/generators/generators/reference-spec-ruby-client.txt
@@ -642,7 +642,7 @@ module Com
                 private
                 def to_query(params={})
                   parts = (params || {}).map { |k,v|
-                    if v.respond_to?(:each)
+                    if v.is_a?(Enumerable)
                       v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                     else
                       "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/lib/src/test/resources/generators/reference-spec-ruby-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ruby-client.txt
@@ -700,7 +700,7 @@ module Com
                 private
                 def to_query(params={})
                   parts = (params || {}).map { |k,v|
-                    if v.respond_to?(:each)
+                    if v.is_a?(Enumerable)
                       v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                     else
                       "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
+++ b/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
@@ -710,7 +710,7 @@ module Com
                 private
                 def to_query(params={})
                   parts = (params || {}).map { |k,v|
-                    if v.respond_to?(:each)
+                    if v.is_a?(Enumerable)
                       v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
                     else
                       "%s=%s" % [k, CGI.escape(v.to_s)]

--- a/ruby-generator/src/main/scala/models/RubyHttpClient.scala
+++ b/ruby-generator/src/main/scala/models/RubyHttpClient.scala
@@ -170,7 +170,7 @@ module HttpClient
     private
     def to_query(params={})
       parts = (params || {}).map { |k,v|
-        if v.respond_to?(:each)
+        if v.is_a?(Enumerable)
           v.map { |el| "%s=%s" % [k, CGI.escape(el.to_s)] }
         else
           "%s=%s" % [k, CGI.escape(v.to_s)]
@@ -227,14 +227,14 @@ module HttpClient
   class PreconditionException < Exception
 
     attr_reader :message
-    
+
     def initialize(message)
       super(message)
       @message = message
     end
 
   end
-          
+
   module Preconditions
 
     def Preconditions.check_argument(expression, error_message=nil)


### PR DESCRIPTION
The existing code doesn't work in Ruby >= 1.9.3. In earlier versions of Ruby,
String inherited from Enumerable and thus #each and #map were both available.
In later versions, this is not the case - #each is available on String but not
and will work in both old and new versions of Ruby.