### PR TITLE
randomString() is a method in 'object Factories'

### DIFF
--- a/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/generator/mock/MockClientGenerator.scala
@@ -154,7 +154,7 @@ case class MockClientGenerator(
       case ScalaPrimitive.DateTimeIso8601 => "new org.joda.time.DateTime()"
       case ScalaPrimitive.Decimal => """BigDecimal("1")"""
       case ScalaPrimitive.Object => "play.api.libs.json.Json.obj()"
-      case ScalaPrimitive.String => "randomString()"
+      case ScalaPrimitive.String => "Factories.randomString()"
       case ScalaPrimitive.Unit => "// unit type"
       case ScalaPrimitive.Uuid => "java.util.UUID.randomUUID"
       case ScalaDatatype.List(_) => "Nil"


### PR DESCRIPTION
make `randomString()` visible to mock traits in the same namespace - qualify it with `Factories`

