### PR TITLE
Use TLS 1.2 for ruby client SSL

### DIFF
--- a/lib/src/test/resources/example-response-with-unit-type.txt
+++ b/lib/src/test/resources/example-response-with-unit-type.txt
@@ -176,6 +176,7 @@ module Com
             def configure_ssl(http)
               Preconditions.assert_class('http', http, Net::HTTP)
               http.use_ssl = true
+              http.ssl_version = :TLSv1_2
               http.verify_mode = OpenSSL::SSL::VERIFY_PEER
               http.cert_store = OpenSSL::X509::Store.new
               http.cert_store.set_default_paths

--- a/lib/src/test/resources/example-union-types-ruby-client.txt
+++ b/lib/src/test/resources/example-union-types-ruby-client.txt
@@ -452,6 +452,7 @@ module Com
                   def configure_ssl(http)
                     Preconditions.assert_class('http', http, Net::HTTP)
                     http.use_ssl = true
+                    http.ssl_version = :TLSv1_2
                     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
                     http.cert_store = OpenSSL::X509::Store.new
                     http.cert_store.set_default_paths

--- a/lib/src/test/resources/generators/collection-json-defaults-ruby-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ruby-client.txt
@@ -220,6 +220,7 @@ module Com
             def configure_ssl(client)
               Preconditions.assert_class('client', client, Net::HTTP)
               client.use_ssl = true
+              client.ssl_version = :TLSv1_2
               client.verify_mode = OpenSSL::SSL::VERIFY_PEER
               client.cert_store = OpenSSL::X509::Store.new
               client.cert_store.set_default_paths

--- a/lib/src/test/resources/generators/generators/reference-spec-ruby-client.txt
+++ b/lib/src/test/resources/generators/generators/reference-spec-ruby-client.txt
@@ -557,6 +557,7 @@ module Com
                 def configure_ssl(client)
                   Preconditions.assert_class('client', client, Net::HTTP)
                   client.use_ssl = true
+                  client.ssl_version = :TLSv1_2
                   client.verify_mode = OpenSSL::SSL::VERIFY_PEER
                   client.cert_store = OpenSSL::X509::Store.new
                   client.cert_store.set_default_paths

--- a/lib/src/test/resources/generators/reference-spec-ruby-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ruby-client.txt
@@ -615,6 +615,7 @@ module Com
                 def configure_ssl(client)
                   Preconditions.assert_class('client', client, Net::HTTP)
                   client.use_ssl = true
+                  client.ssl_version = :TLSv1_2
                   client.verify_mode = OpenSSL::SSL::VERIFY_PEER
                   client.cert_store = OpenSSL::X509::Store.new
                   client.cert_store.set_default_paths

--- a/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
+++ b/lib/src/test/resources/ruby-client-generator-gilt-0.0.1-test.txt
@@ -625,6 +625,7 @@ module Com
                 def configure_ssl(http)
                   Preconditions.assert_class('http', http, Net::HTTP)
                   http.use_ssl = true
+                  http.ssl_version = :TLSv1_2
                   http.verify_mode = OpenSSL::SSL::VERIFY_PEER
                   http.cert_store = OpenSSL::X509::Store.new
                   http.cert_store.set_default_paths

--- a/ruby-generator/src/main/scala/models/RubyHttpClient.scala
+++ b/ruby-generator/src/main/scala/models/RubyHttpClient.scala
@@ -85,6 +85,7 @@ module HttpClient
     def configure_ssl(http)
       Preconditions.assert_class('http', http, Net::HTTP)
       http.use_ssl = true
+      http.ssl_version = :TLSv1_2
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       http.cert_store = OpenSSL::X509::Store.new
       http.cert_store.set_default_paths


### PR DESCRIPTION
The current Ruby Client defaults to using the old and insecure TLS 1 SSL protocol. Use TLS 1.2 as this is already widespread and supported.