### PR TITLE
Add Product and Serializable traits to sealed traits for enums.

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -4,9 +4,9 @@
  */
 package com.bryzek.apidoc.example.union.types.v0.models {
 
-  sealed trait Foobar
+  sealed trait Foobar extends _root_.scala.Product with _root_.scala.Serializable
 
-  @deprecated("to be removed") sealed trait User
+  @deprecated("to be removed") sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   case class GuestUser(
     guid: _root_.java.util.UUID,
@@ -460,7 +460,7 @@ package com.bryzek.apidoc.example.union.types.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -4,9 +4,9 @@
  */
 package com.bryzek.apidoc.example.union.types.v0.models {
 
-  sealed trait Foobar
+  sealed trait Foobar extends _root_.scala.Product with _root_.scala.Serializable
 
-  @deprecated("to be removed") sealed trait User
+  @deprecated("to be removed") sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   case class GuestUser(
     guid: _root_.java.util.UUID,
@@ -498,7 +498,7 @@ package com.bryzek.apidoc.example.union.types.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-ning-client.txt
@@ -271,7 +271,7 @@ package com.gilt.test.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-23.txt
@@ -289,7 +289,7 @@ package com.gilt.test.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -270,7 +270,7 @@ package com.gilt.quality.v0.models {
   /**
    * An external service with which an organization can integrate.
    */
-  sealed trait ExternalServiceName
+  sealed trait ExternalServiceName extends _root_.scala.Product with _root_.scala.Serializable
 
   object ExternalServiceName {
 
@@ -311,7 +311,7 @@ package com.gilt.quality.v0.models {
    * A publication represents something that a user can subscribe to. An example
    * would be subscribing via email to the publication of all new incidents.
    */
-  sealed trait Publication
+  sealed trait Publication extends _root_.scala.Product with _root_.scala.Serializable
 
   object Publication {
 
@@ -367,7 +367,7 @@ package com.gilt.quality.v0.models {
 
   }
 
-  sealed trait Response
+  sealed trait Response extends _root_.scala.Product with _root_.scala.Serializable
 
   object Response {
 
@@ -402,7 +402,7 @@ package com.gilt.quality.v0.models {
 
   }
 
-  sealed trait Severity
+  sealed trait Severity extends _root_.scala.Product with _root_.scala.Serializable
 
   object Severity {
 
@@ -439,7 +439,7 @@ package com.gilt.quality.v0.models {
   /**
    * Describes what needs to be reviewed about a specific incident
    */
-  sealed trait Task
+  sealed trait Task extends _root_.scala.Product with _root_.scala.Serializable
 
   object Task {
 

--- a/lib/src/test/resources/generators/reference-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-spec-ning-client.txt
@@ -74,7 +74,7 @@ package com.bryzek.apidoc.reference.api.v0.models {
     users: Seq[com.bryzek.apidoc.reference.api.v0.models.User]
   )
 
-  sealed trait AgeGroup
+  sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 
   object AgeGroup {
 
@@ -750,7 +750,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/reference-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-23.txt
@@ -74,7 +74,7 @@ package com.bryzek.apidoc.reference.api.v0.models {
     users: Seq[com.bryzek.apidoc.reference.api.v0.models.User]
   )
 
-  sealed trait AgeGroup
+  sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 
   object AgeGroup {
 
@@ -777,7 +777,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-ning-client.txt
@@ -74,7 +74,7 @@ package com.bryzek.apidoc.reference.api.v0.models {
     users: Seq[com.bryzek.apidoc.reference.api.v0.models.User]
   )
 
-  sealed trait AgeGroup
+  sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 
   object AgeGroup {
 
@@ -752,7 +752,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-23.txt
@@ -74,7 +74,7 @@ package com.bryzek.apidoc.reference.api.v0.models {
     users: Seq[com.bryzek.apidoc.reference.api.v0.models.User]
   )
 
-  sealed trait AgeGroup
+  sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 
   object AgeGroup {
 
@@ -779,7 +779,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/lib/src/test/resources/play2enums-example.txt
+++ b/lib/src/test/resources/play2enums-example.txt
@@ -1,4 +1,4 @@
-sealed trait AgeGroup
+sealed trait AgeGroup extends _root_.scala.Product with _root_.scala.Serializable
 
 object AgeGroup {
 
@@ -32,7 +32,7 @@ object AgeGroup {
 
 }
 
-sealed trait Genre
+sealed trait Genre extends _root_.scala.Product with _root_.scala.Serializable
 
 object Genre {
 

--- a/lib/src/test/resources/scala-union-models-case-classes.txt
+++ b/lib/src/test/resources/scala-union-models-case-classes.txt
@@ -1,6 +1,6 @@
 package test.apidoc.apidoctest.v0.models {
 
-  sealed trait User
+  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   case class GuestUser(
     id: Long,

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -4,12 +4,12 @@
  */
 package com.bryzek.apidoc.example.union.types.discriminator.v0.models {
 
-  sealed trait User
+  sealed trait User extends _root_.scala.Product with _root_.scala.Serializable
 
   /**
    * Defines the valid discriminator values for the type User
    */
-  sealed trait UserDiscriminator
+  sealed trait UserDiscriminator extends _root_.scala.Product with _root_.scala.Serializable
 
   object UserDiscriminator {
 
@@ -419,7 +419,7 @@ package com.bryzek.apidoc.example.union.types.discriminator.v0 {
 
   }
 
-  sealed trait Authorization
+  sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
   object Authorization {
     case class Basic(username: String, password: Option[String] = None) extends Authorization
   }

--- a/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaCaseClasses.scala
@@ -90,7 +90,7 @@ trait ScalaCaseClasses extends CodeGenerator {
 
   def generateUnionTrait(union: ScalaUnion): String = {
     // TODO: handle primitive types
-    s"${ScalaUtil.deprecationString(union.deprecation)}sealed trait ${union.name}"
+    s"${ScalaUtil.deprecationString(union.deprecation)}sealed trait ${union.name} extends _root_.scala.Product with _root_.scala.Serializable"
   }
 
   def generateUnionDiscriminatorTrait(union: ScalaUnion): Option[String] = {

--- a/scala-generator/src/main/scala/models/generator/ScalaClientAuthClassses.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaClientAuthClassses.scala
@@ -3,7 +3,7 @@ package scala.generator
 object ScalaClientAuthClassses {
 
   def apply(): String = """
-sealed trait Authorization
+sealed trait Authorization extends _root_.scala.Product with _root_.scala.Serializable
 object Authorization {
   case class Basic(username: String, password: Option[String] = None) extends Authorization
 }

--- a/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaEnums.scala
@@ -18,7 +18,7 @@ case class ScalaEnums(
     import lib.Text._
     Seq(
       enum.description.map { desc => ScalaUtil.textToComment(desc) + "\n" }.getOrElse("") +
-      s"sealed trait ${enum.name}" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse(""),
+      s"sealed trait ${enum.name}" + ScalaUtil.extendsClause(unions.map(_.name)).map(s => s" $s").getOrElse(" extends _root_.scala.Product with _root_.scala.Serializable"),
       s"${ScalaUtil.deprecationString(enum.deprecation)}object ${enum.name} {",
       buildValues().indent(2),
       s"}"

--- a/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
+++ b/scala-generator/src/main/scala/models/generator/ScalaUnionDiscriminator.scala
@@ -16,7 +16,7 @@ case class ScalaUnionDiscriminator(
     Seq(
       Seq(
         ScalaUtil.textToComment(s"Defines the valid ${discriminator} values for the type ${union.name}"),
-        s"sealed trait $className"
+        s"sealed trait $className extends _root_.scala.Product with _root_.scala.Serializable"
       ).mkString("\n"),
       s"${ScalaUtil.deprecationString(union.deprecation)}object $className {",
       buildTypes().indent(2),


### PR DESCRIPTION
This offers better type inference for values in those traits.

Without these traits:

```scala
sealed trait Foo
case class Foo1(a: String) extends Foo
case object Foo2 extends Foo

scala> List(Foo1("a"), Foo2)
res0: List[Product with Serializable with Foo] = List(Foo1(a), Foo2)
```

With these traits:

```scala
sealed trait Foo extends _root_.scala.Product with _root_.scala.Serializable
case class Foo1(a: String) extends Foo
case object Foo2 extends Foo

scala> List(Foo1("a"), Foo2)
res0: List[Foo] = List(Foo1(a), Foo2)
```