### PR TITLE
Enable recursively defined union types

### DIFF
--- a/lib/src/test/resources/example-union-types-ning-client.txt
+++ b/lib/src/test/resources/example-union-types-ning-client.txt
@@ -245,7 +245,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
       )
     }
 
-    def jsObjectFoobar(obj: com.bryzek.apidoc.example.union.types.v0.models.Foobar) = {
+    def jsObjectFoobar(obj: com.bryzek.apidoc.example.union.types.v0.models.Foobar): play.api.libs.json.JsObject = {
       obj match {
         case x: com.bryzek.apidoc.example.union.types.v0.models.Foo => play.api.libs.json.Json.obj("foo" -> play.api.libs.json.JsString(x.toString))
         case x: com.bryzek.apidoc.example.union.types.v0.models.Bar => play.api.libs.json.Json.obj("bar" -> play.api.libs.json.JsString(x.toString))
@@ -273,7 +273,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
       )
     }
 
-    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.v0.models.User) = {
+    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
         case x: com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
         case x: com.bryzek.apidoc.example.union.types.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))

--- a/lib/src/test/resources/example-union-types-play-23.txt
+++ b/lib/src/test/resources/example-union-types-play-23.txt
@@ -245,7 +245,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
       )
     }
 
-    def jsObjectFoobar(obj: com.bryzek.apidoc.example.union.types.v0.models.Foobar) = {
+    def jsObjectFoobar(obj: com.bryzek.apidoc.example.union.types.v0.models.Foobar): play.api.libs.json.JsObject = {
       obj match {
         case x: com.bryzek.apidoc.example.union.types.v0.models.Foo => play.api.libs.json.Json.obj("foo" -> play.api.libs.json.JsString(x.toString))
         case x: com.bryzek.apidoc.example.union.types.v0.models.Bar => play.api.libs.json.Json.obj("bar" -> play.api.libs.json.JsString(x.toString))
@@ -273,7 +273,7 @@ package com.bryzek.apidoc.example.union.types.v0.models {
       )
     }
 
-    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.v0.models.User) = {
+    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
         case x: com.bryzek.apidoc.example.union.types.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
         case x: com.bryzek.apidoc.example.union.types.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))

--- a/lib/src/test/resources/scala-union-enums-json.txt
+++ b/lib/src/test/resources/scala-union-enums-json.txt
@@ -8,7 +8,7 @@ implicit def jsonReadsApiDocTestUserType: play.api.libs.json.Reads[UserType] = {
   )
 }
 
-def jsObjectUserType(obj: test.apidoc.apidoctest.v0.models.UserType) = {
+def jsObjectUserType(obj: test.apidoc.apidoctest.v0.models.UserType): play.api.libs.json.JsObject = {
   obj match {
     case x: test.apidoc.apidoctest.v0.models.MemberType => play.api.libs.json.Json.obj("member_type" -> play.api.libs.json.JsString(x.toString))
     case x: test.apidoc.apidoctest.v0.models.RoleType => play.api.libs.json.Json.obj("role_type" -> play.api.libs.json.JsString(x.toString))

--- a/lib/src/test/resources/scala-union-models-json-union-type-writers.txt
+++ b/lib/src/test/resources/scala-union-models-json-union-type-writers.txt
@@ -1,4 +1,4 @@
-def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User) = {
+def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User): play.api.libs.json.JsObject = {
   obj match {
     case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
     case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))

--- a/lib/src/test/resources/scala-union-models-json.txt
+++ b/lib/src/test/resources/scala-union-models-json.txt
@@ -48,7 +48,7 @@ implicit def jsonReadsApiDocTestUser: play.api.libs.json.Reads[User] = {
   )
 }
 
-def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User) = {
+def jsObjectUser(obj: test.apidoc.apidoctest.v0.models.User): play.api.libs.json.JsObject = {
   obj match {
     case x: test.apidoc.apidoctest.v0.models.RegisteredUser => play.api.libs.json.Json.obj("registered_user" -> jsObjectRegisteredUser(x))
     case x: test.apidoc.apidoctest.v0.models.GuestUser => play.api.libs.json.Json.obj("guest_user" -> jsObjectGuestUser(x))

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -202,7 +202,7 @@ package com.bryzek.apidoc.example.union.types.discriminator.v0.models {
       }
     }
 
-    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.discriminator.v0.models.User) = {
+    def jsObjectUser(obj: com.bryzek.apidoc.example.union.types.discriminator.v0.models.User): play.api.libs.json.JsObject = {
       obj match {
         case x: com.bryzek.apidoc.example.union.types.discriminator.v0.models.RegisteredUser => jsObjectRegisteredUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "registered_user")
         case x: com.bryzek.apidoc.example.union.types.discriminator.v0.models.GuestUser => jsObjectGuestUser(x) ++ play.api.libs.json.Json.obj("discriminator" -> "guest_user")

--- a/scala-generator/src/main/scala/models/Play2Json.scala
+++ b/scala-generator/src/main/scala/models/Play2Json.scala
@@ -183,7 +183,7 @@ case class Play2Json(
     val method = play2JsonCommon.toJsonObjectMethodName(ssd.namespaces, union.name)
 
     Seq(
-      s"def $method(obj: ${union.qualifiedName}) = {",
+      s"def $method(obj: ${union.qualifiedName}): play.api.libs.json.JsObject = {",
       s"  obj match {",
       unionTypesWithNames(union).map { case (t, typeName) =>
         val json = getJsonValueForUnion(t.datatype, "x")
@@ -199,7 +199,7 @@ case class Play2Json(
     val method = play2JsonCommon.toJsonObjectMethodName(ssd.namespaces, union.name)
 
     Seq(
-      s"def $method(obj: ${union.qualifiedName}) = {",
+      s"def $method(obj: ${union.qualifiedName}): play.api.libs.json.JsObject = {",
       Seq(
         "obj match {",
         Seq(


### PR DESCRIPTION
Example:

```json
{
  "name": "recursive",

  "unions": {
    "foobar": {
      "discriminator": "type",
      "types": [
        { "type": "foo" },
        { "type": "bar" }
      ]
    }
  },

  "models": {
    "foo": {
      "fields": [
        { "name": "recurse", "type": "foobar" }
      ]
    },
    "bar": {
      "fields": [
        { "name": "idk", "type": "string" }
      ]
    }
  }
}
```

Notice how `foobar` can be a `foo`, and `foo` has a field of type `foobar`. This improves play json code generation by adding return types