### PR TITLE
Avoid calling implicits

### DIFF
--- a/scala-generator/src/main/scala/models/Play2Json.scala
+++ b/scala-generator/src/main/scala/models/Play2Json.scala
@@ -337,7 +337,7 @@ case class Play2Json(
           val path = s"""(__ \\ "${field.originalName}")"""
           val reader = {
             if (beLazy)
-              s"""lazyReadNullable(${play2JsonCommon.implicitReaderName(getShortName(inner))})"""
+              s"""lazyReadNullable(play.api.libs.json.Reads.of[${inner.name}])"""
             else
               s"""readNullable[${inner.name}]"""
           }
@@ -348,7 +348,7 @@ case class Play2Json(
           val path = s"""(__ \\ "${field.originalName}")"""
           val reader = {
             if (beLazy)
-              s"""lazyRead(${play2JsonCommon.implicitReaderName(getShortName(datatype))})"""
+              s"""lazyRead(play.api.libs.json.Reads.of[${datatype.name}])"""
             else
               s"""read[${datatype.name}]"""
           }


### PR DESCRIPTION
This should fix https://github.com/mbryzek/apidoc/issues/632.

Calling the read method directly was causing an issue when the type was a list. `Reads.of` will call the appropriate read methods, in the right order.